### PR TITLE
Close the sockets so that the OS doesn't get confused

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Your private data should be safe with uLogMe:
 ----
 
 ## :bug: Known issues
-- You may see *"address already in use"* if you try to run `python ulogme_serve.py`. Sometimes the system can get confused and takes a while to update what ports are being used (or the port can be actually used by another software). Use the optional argument to specify a different port, for example `$ python ulogme_serve.py 8125` and then go to `http://localhost:8125/` instead, for example.
+- You may see *"address already in use"* if you try to run `python ulogme_serve.py`. This may be because the port is being used by another program. Use the optional argument to specify a different port, for example `$ python ulogme_serve.py 8125` and then go to `http://localhost:8125/` instead, for example.
 - Overview page is blank. Are you sure your browser supports ECMAScript 6 ? You can check it with these tools: [ES6 checker](https://ruanyf.github.io/es-checker/) or [Compat-Table ES6](https://kangax.github.io/compat-table/es6/). Any recent browser should be fine (Chrome and Firefox, at least).
 
 ----

--- a/scripts/ulogme_serve.py
+++ b/scripts/ulogme_serve.py
@@ -119,6 +119,6 @@ if __name__ == "__main__":
             print("\nError, ulogme_serve.py was interrupted, giving:")
             print("Exception: e =", e)
             # print("Exception: dir(e) =", dir(e))  # DEBUG
-    except KeyboardInterrupt:
-        print("\nYou probably asked to interrupt the 'ulogme_serve.py' HTTP server ...")
-        print("You should wait for some time before using the port {} again. (about 1 minute on Ubuntu)".format(PORT))
+    finally:
+        print("\nClosing HTTP server...")
+        httpd.server_close()


### PR DESCRIPTION
Credit to @blackdaemon: https://github.com/blackdaemon/ulogme/commit/85598fa5763d2c626af859cae6b03a8cee17a3d0 . I find these by looking at this graph: https://github.com/karpathy/ulogme/network

Doing this means the OS won't think the port is still occupied for a minute.

Let me know if submitting suggestions in issues is better for you than submitting pull requests.